### PR TITLE
Add NonGNU ELPA badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # boxquote.el
 Quote text with a semi-box.
 
+[![NonGNU ELPA](https://elpa.nongnu.org/nongnu/boxquote.svg)](https://elpa.nongnu.org/nongnu/boxquote.html)
 [![MELPA Stable](http://stable.melpa.org/packages/boxquote-badge.svg)](http://stable.melpa.org/#/boxquote)
 [![MELPA](https://melpa.org/packages/boxquote-badge.svg)](https://melpa.org/#/boxquote)
 


### PR DESCRIPTION
Hi!

We have now added this package to [NonGNU ELPA](http://elpa.nongnu.org/nongnu/boxquote.html) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others. This particular commit adds a badge, because it looks nice and is occasionally useful.

The main difference between NonGNU ELPA and MELPA is that only tagged versions of packages are released. This means that a new release will be automatically when you bump the "Version" commentary header in this repository. You can bump the package version (thereby releasing a new version) at your convenience.

Please let me know if you have any questions about any of this.

Thanks!

PS. I see some rendering issues with the README on the package page; I will look into how we can improve the display.