### PR TITLE
Set lexical-binding explicitly

### DIFF
--- a/boxquote.el
+++ b/boxquote.el
@@ -1,4 +1,5 @@
-;;; boxquote.el --- Quote text with a semi-box.
+;;; boxquote.el --- Quote text with a semi-box  -*- lexical-binding: nil -*-
+
 ;; Copyright 1999-2022 by Dave Pearson <davep@davep.org>
 
 ;; Author: Dave Pearson <davep@davep.org>


### PR DESCRIPTION
Emacs 30.0.50 has started to warn when this variable isn't set,
presumably so that the default can be changed from nil to t in
a few years.

It would be better to enable lexical-binding.

I also sneaked in a newline and removed a period to comply with
the summary line conventions.